### PR TITLE
Remove defunct feedback.rackspace link

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 ### Report an issue with the documentation
 
-Describe your documentation issue in  the relevant section. Submit product operation or 
-performance issues to the Rackspace product team at https://feedback.rackspace.com/.
+Describe your documentation issue in the relevant section.
+
 
 **Link to documentation with issue:**  
 


### PR DESCRIPTION
(Not a published change)
